### PR TITLE
Use asleep as an adjective instead of noun or verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 aws-cost-saver
 =======================
 
-A tiny CLI tool to help save costs in development environments when you're sleep and don't need them!
+A tiny CLI tool to help save costs in development environments when you're asleep and don't need them!
 
 * [Usage](#usage)
 * [Tricks](#tricks)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-cost-saver",
-  "description": "A tiny CLI tool to help save costs in development environments when you're sleep and don't need them!",
+  "description": "A tiny CLI tool to help save costs in development environments when you're asleep and don't need them!",
   "version": "0.0.3",
   "author": "aramalipoor",
   "bin": {


### PR DESCRIPTION
Let's use the word `asleep` instead of `sleep` when describing this solution. Keep in mind that the Github About section will also need to be updated to match the change. Thanks!